### PR TITLE
Fix from Source1 made by Coruja, addressing the following problems: Explosion potions not working correctly and Hidden chars are not shown when being stumbled

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -243,3 +243,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 28-10-2017, Drk84
 - [Port from Source,  08-05-2016, Coruja] Fixed: Explosion potions not working correctly.
+
+28-10-2017, Drk84
+- [Port from Source,  07-02-2017, Coruja] Fixed: Hidden/Invisible chars not getting revealed when being stumbled.

--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -240,3 +240,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 24-10-2017, Drk84
 - [Port from Source, 27-09-2016, Coruja]  Fixed: Worldsave not saving DAM/ARMOR properties set manually on chars/items already placed on world.
+
+28-10-2017, Drk84
+- [Port from Source,  08-05-2016, Coruja] Fixed: Explosion potions not working correctly.

--- a/src/game/chars/CCharact.cpp
+++ b/src/game/chars/CCharact.cpp
@@ -2973,7 +2973,7 @@ CRegionBase * CChar::CanMoveWalkTo( CPointBase & ptDst, bool fCheckChars, bool f
 			return NULL;
 		}
 
-		if ( Stat_GetVal(STAT_DEX) <= 0 && !IsStatFlag(STATF_DEAD) )
+		if ( (Stat_GetVal(STAT_DEX) <= 0) && (!IsStatFlag(STATF_DEAD)) )
 		{
 			SysMessageDefault(DEFMSG_MSG_FATIGUE);
 			return NULL;
@@ -3021,14 +3021,14 @@ CRegionBase * CChar::CanMoveWalkTo( CPointBase & ptDst, bool fCheckChars, bool f
 	short iStamReq = 0;
 	if ( fCheckChars && !IsStatFlag(STATF_DEAD|STATF_Sleeping|STATF_Insubstantial) )
 	{
-		CItem * pPoly = LayerFind(LAYER_SPELL_Polymorph);
-		CWorldSearch AreaChars( ptDst );
+		CItem *pPoly = LayerFind(LAYER_SPELL_Polymorph);
+		CWorldSearch AreaChars(ptDst);
 		for (;;)
 		{
-			CChar * pChar = AreaChars.GetChar();
-			if ( pChar == NULL )
+			CChar *pChar = AreaChars.GetChar();
+			if (!pChar )
 				break;
-			if ( pChar == this || abs(pChar->GetTopZ() - ptDst.m_z) > 5 || pChar->IsStatFlag(STATF_Insubstantial) )
+			if ( (pChar == this) || (abs(pChar->GetTopZ() - ptDst.m_z) > 5) || (pChar->IsStatFlag(STATF_Insubstantial)) )
 				continue;
 			if ( m_pNPC && pChar->m_pNPC )	// NPCs can't walk over another NPC
 				return NULL;
@@ -3036,7 +3036,7 @@ CRegionBase * CChar::CanMoveWalkTo( CPointBase & ptDst, bool fCheckChars, bool f
 			iStamReq = 10;
 			if ( IsPriv(PRIV_GM) || pChar->IsStatFlag(STATF_DEAD|STATF_Invisible|STATF_Hidden) )
 				iStamReq = 0;
-			else if ( pPoly && pPoly->m_itSpell.m_spell == SPELL_Wraith_Form && GetTopMap() == 0 )		// chars under Wraith Form effect can always walk through chars in Felucca
+			else if ( (pPoly && pPoly->m_itSpell.m_spell == SPELL_Wraith_Form) && (GetTopMap() == 0) )		// chars under Wraith Form effect can always walk through chars in Felucca
 				iStamReq = 0;
 
 			TRIGRET_TYPE iRet = TRIGRET_RET_DEFAULT;
@@ -3048,11 +3048,12 @@ CRegionBase * CChar::CanMoveWalkTo( CPointBase & ptDst, bool fCheckChars, bool f
 
 				if ( iRet == TRIGRET_RET_TRUE )
 					return NULL;
+				if (iStamReq < 0)
+					continue;
 			}
 
-			if ( iStamReq <= 0 )
-				continue;
-			if ( Stat_GetVal(STAT_DEX) < Stat_GetMax(STAT_DEX) )
+			
+			if ( (iStamReq > 0) && (Stat_GetVal(STAT_DEX) < Stat_GetMax(STAT_DEX)) )
 				return NULL;
 
 			tchar *pszMsg = Str_GetTemp();
@@ -3083,7 +3084,7 @@ CRegionBase * CChar::CanMoveWalkTo( CPointBase & ptDst, bool fCheckChars, bool f
 	{
 		EXC_SET("Stamina penalty");
 		// Chance to drop more stamina if running or overloaded
-		CVarDefCont * pVal = GetKey("OVERRIDE.RUNNINGPENALTY", true);
+		CVarDefCont *pVal = GetKey("OVERRIDE.RUNNINGPENALTY", true);
 		if ( IsStatFlag(STATF_Fly|STATF_Hovering) )
 			iWeightLoadPercent += pVal ? (int)(pVal->GetValNum()) : g_Cfg.m_iStamRunningPenalty;
 

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -261,6 +261,7 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 				pItem->m_itPotion.m_ignited = 1;	// ignite it
 				pItem->m_uidLink = m_pChar->GetUID();
 				pItem->SetTimeout(TICK_PER_SEC);
+				m_tmUseItem.m_pParent = pItem->GetParent();
 				addTarget(CLIMODE_TARG_USE_ITEM, g_Cfg.GetDefaultMsg(DEFMSG_SELECT_POTION_TARGET), true, true, pItem->m_itPotion.m_tick * TICK_PER_SEC);
 				return true;
 			}


### PR DESCRIPTION
Explosions Potions not working:
See:
https://github.com/Sphereserver/Source/commit/5304d8e20ecdb8f5bd2b8efebc35d219d301fc37
And:
https://github.com/Sphereserver/Source/issues/61

Hidden chars are not shown when being stumbled:
See:
Sphereserver/Source@9b58fb8
And:
Sphereserver/Source#84