### PR TITLE
Port from Source1 addressing the following issue: Char death counting…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -251,3 +251,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 30-10-2017, Drk84
 - [Port from Source, 17-10-2016, Coruja] Fixed: NPCs losing 'statf_spawned' flag after server restart.
 - [Port from Source, 30-01-2017, Coruja] Fixed: ML/SA/HS/TOL doors not working correctly.
+
+01-11-2017, Drk84
+- [Port from Source, 12-01-2017, Coruja] Fixed: Char death counting kill/fame/karma gain for killers that started the attack but don't have caused any damage yet.

--- a/src/game/chars/CCharact.cpp
+++ b/src/game/chars/CCharact.cpp
@@ -2784,7 +2784,7 @@ bool CChar::Death()
 	for ( size_t count = 0; count < m_lastAttackers.size(); count++ )
 	{
 		pKiller = CUID(m_lastAttackers.at(count).charUID).CharFind();
-		if ( pKiller )
+		if ( pKiller && (m_lastAttackers.at(count).amountDone > 0) )
 		{
 			if ( IsTrigUsed(TRIGGER_KILL) )
 			{


### PR DESCRIPTION
… kill/fame/karma gain for killers that started the attack but don't have caused any damage yet.
See:
https://github.com/Sphereserver/Source/commit/a4095b06b2f1652e6cc0fd1f2d70aa8585b5f27d