### PR TITLE
Port from Source1 addressing the following issue: TimerCall setting on sphere.ini using wrong time format

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -304,3 +304,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed: nested random ranges not being parsed correctly.
 - Fixed: random ranges ignoring the last element-weight couple.
 - Changed: ADD command does not show anymore the console error if the argument is invalid. The sysmessage is still displayed.
+
+05-12-2017, Drk84
+- [Port from Source, 05-09-2016, Coruja]  Fixed: TimerCall setting on sphere.ini using wrong time format (hours instead minutes) to call f_onserver_timer function

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -1181,7 +1181,7 @@ bool CServerConfig::r_LoadVal( CScript &s )
 			//PrintEFOFFlags(false, true);
 			break;
 		case RC_TIMERCALL:
-			m_iTimerCall = s.GetArgVal() * TICK_PER_SEC;
+			m_iTimerCall = s.GetArgVal() * 60 * TICK_PER_SEC;
 			break;
 
 		case RC_TOOLTIPCACHE:
@@ -1699,7 +1699,7 @@ bool CServerConfig::r_WriteVal( lpctstr pszKey, CSString & sVal, CTextConsole * 
 			sVal.FormatLLVal( ( - g_World.GetTimeDiff( g_World.m_timeStartup )) / TICK_PER_SEC );
 			return true;
 		case RC_TIMERCALL:
-			sVal.FormatVal(m_iTimerCall / TICK_PER_SEC);
+			sVal.FormatVal(m_iTimerCall / ( 60 * TICK_PER_SEC));
 			break;
 		case RC_VERSION:
 			sVal = g_szServerDescription;

--- a/src/game/CWorld.cpp
+++ b/src/game/CWorld.cpp
@@ -2478,8 +2478,8 @@ void CWorld::OnTick()
 	{
 		if ( g_Cfg.m_iTimerCall )
 		{
-			m_timeCallUserFunc = GetCurrentTime() + g_Cfg.m_iTimerCall*60*TICK_PER_SEC;
-			CScriptTriggerArgs args(g_Cfg.m_iTimerCall);
+			m_timeCallUserFunc = GetCurrentTime() + g_Cfg.m_iTimerCall;
+			CScriptTriggerArgs args(g_Cfg.m_iTimerCall / (60 * TICK_PER_SEC));
 			g_Serv.r_Call("f_onserver_timer", &g_Serv, &args);
 		}
 	}


### PR DESCRIPTION
Fixed: TimerCall setting on sphere.ini using wrong time format

Pratically, at least in Windows build, if you put timercall = 1 the function f_onserver_timer will be called every 10 minutes instead of one minute.

See: https://github.com/Sphereserver/Source/commit/9a5109b6bf5405a20d6dd28100717c51f5dba87c