### PR TITLE
 Fix: The spell effect value was calculated twice for spells that equipped a "spell memory item" (Ex: Bless, Curse and so on) on a character, causing also to ignore the

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -346,6 +346,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 	if set, will be used instead of obtaining it from the SOUND property. Set one of these overrides to -1 if you don't want that action-related sound to be played.
 
 14-01-2018, Drk84
-- Fixed: The effect value of spells that equips a "memory item" on a character(Bless, Curse and so on) was calculated twice, also causing     to ignore the 
+- Fixed: The effect value of spells that equips a "memory item" on a character(Bless, Curse and so on) was calculated twice, also causing to ignore the 
 	value of local.effect.
 											

--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -344,3 +344,8 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 05-01-2018, Nolok
 - Added: SOUNDIDLE, SOUNDNOTICE, SOUNDHIT, SOUNDGETHIT, SOUNDDIE CharDef properties. When a creature emits a sound linked to an action, the sound ID of	the corresponding override,
 	if set, will be used instead of obtaining it from the SOUND property. Set one of these overrides to -1 if you don't want that action-related sound to be played.
+
+14-01-2018, Drk84
+- Fixed: The effect value of spells that equips a "memory item" on a character(Bless, Curse and so on) was calculated twice, also causing     to ignore the 
+	value of local.effect.
+											

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -891,7 +891,7 @@ private:
 	bool Spell_Recall(CItem * pRune, bool fGate);
 	SPELL_TYPE Spell_GetIndex(SKILL_TYPE skill = SKILL_NONE);	//gets first spell for the magic skill given.
 	SPELL_TYPE Spell_GetMax(SKILL_TYPE skill = SKILL_NONE);	//gets first spell for the magic skill given.
-	CItem * Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iSkillLevel, int iDuration, CObjBase * pSrc = NULL, bool bEquip = true );
+	CItem * Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iEffect, int iDuration, CObjBase * pSrc = NULL, bool bEquip = true );
 	bool Spell_Equip_OnTick( CItem * pItem );
 
 	void Spell_Field(CPointMap pt, ITEMID_TYPE idEW, ITEMID_TYPE idNS, uint fieldWidth, uint fieldGauge, int iSkill, CChar * pCharSrc = NULL, ITEMID_TYPE idnewEW = static_cast<ITEMID_TYPE>(NULL), ITEMID_TYPE idnewNS = static_cast<ITEMID_TYPE>(NULL), int iDuration = 0, HUE_TYPE iColor = HUE_DEFAULT);

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -518,7 +518,7 @@ void CChar::CallGuards( CChar * pCriminal )
 
 		if (pCriminal->m_pArea->m_TagDefs.GetKeyNum("RED", true))
 			pGuard->m_TagDefs.SetNum("NAME.HUE", g_Cfg.m_iColorNotoEvil, true);
-		pGuard->Spell_Effect_Create(SPELL_Summon, LAYER_SPELL_Summon, 1000, g_Cfg.m_iGuardLingerTime);
+		pGuard->Spell_Effect_Create(SPELL_Summon, LAYER_SPELL_Summon, g_Cfg.GetSpellEffect(SPELL_Summon, 1000), g_Cfg.m_iGuardLingerTime);
 		pGuard->Spell_Teleport(pCriminal->GetTopPoint(), false, false);
 	}
 	pGuard->NPC_LookAtCharGuard(pCriminal, true);

--- a/src/game/chars/CCharNotoriety.cpp
+++ b/src/game/chars/CCharNotoriety.cpp
@@ -362,7 +362,7 @@ void CChar::Noto_Murder()
 		SysMessageDefault(DEFMSG_MSG_MURDERER);
 
 	if ( m_pPlayer && m_pPlayer->m_wMurders )
-		Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_Murders, 0, g_Cfg.m_iMurderDecayTime, NULL);
+		Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_Murders, g_Cfg.GetSpellEffect(SPELL_NONE, 0), g_Cfg.m_iMurderDecayTime, NULL);
 }
 
 bool CChar::Noto_Criminal( CChar * pChar )
@@ -387,7 +387,7 @@ bool CChar::Noto_Criminal( CChar * pChar )
 	if ( !IsStatFlag(STATF_Criminal) )
 		SysMessageDefault(DEFMSG_MSG_GUARDS);
 
-	Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_Criminal, 0, decay);
+	Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_Criminal, g_Cfg.GetSpellEffect(SPELL_NONE, 0), decay);
 	return true;
 }
 

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2327,7 +2327,7 @@ int CChar::Skill_SpiritSpeak( SKTRIG_TYPE stage )
 			Sound( 0x24a );
 
 		SysMessageDefault( DEFMSG_SPIRITSPEAK_SUCCESS );
-		Spell_Effect_Create( SPELL_NONE, LAYER_FLAG_SpiritSpeak, 1, 4*60*TICK_PER_SEC, this );
+		Spell_Effect_Create( SPELL_NONE, LAYER_FLAG_SpiritSpeak, g_Cfg.GetSpellEffect(SPELL_NONE, 1), 4*60*TICK_PER_SEC, this );
 		return 0;
 	}
 

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -1724,7 +1724,7 @@ bool CChar::Spell_Equip_OnTick( CItem * pItem )
 	return false;
 }
 
-CItem * CChar::Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iSkillLevel, int iDuration, CObjBase * pSrc, bool bEquip )
+CItem * CChar::Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iEffect, int iDuration, CObjBase * pSrc, bool bEquip )
 {
 	ADDTOCALLSTACK("CChar::Spell_Effect_Create");
 	// Attach an effect to the Character.
@@ -1781,7 +1781,7 @@ CItem * CChar::Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iSki
 	pSpell->SetType(IT_SPELL);
 	pSpell->SetDecayTime(iDuration);
 	pSpell->m_itSpell.m_spell = (word)(spell);
-	pSpell->m_itSpell.m_spelllevel = (word)(g_Cfg.GetSpellEffect(spell, iSkillLevel));
+	pSpell->m_itSpell.m_spelllevel = (word)iEffect;
 	pSpell->m_itSpell.m_spellcharges = 1;
 	if ( pSrc )
 		pSpell->m_uidLink = pSrc->GetUID();
@@ -3264,7 +3264,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		case SPELL_Bless:
 		case SPELL_Mana_Drain:
 		case SPELL_Mass_Curse:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Heal:
@@ -3277,16 +3277,16 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 			break;
 
 		case SPELL_Reactive_Armor:
-			Spell_Effect_Create( spell, LAYER_SPELL_Reactive, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, LAYER_SPELL_Reactive, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Magic_Reflect:
-			Spell_Effect_Create( spell, LAYER_SPELL_Magic_Reflect, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, LAYER_SPELL_Magic_Reflect, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Poison:
 		case SPELL_Poison_Field:
-			Spell_Effect_Create( spell, LAYER_FLAG_Poison, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, LAYER_FLAG_Poison, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Cure:
@@ -3299,11 +3299,11 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 
 		case SPELL_Protection:
 		case SPELL_Arch_Prot:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Protection, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Protection, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Summon:
-			Spell_Effect_Create( spell,	LAYER_SPELL_Summon, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell,	LAYER_SPELL_Summon, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Dispel:
@@ -3319,18 +3319,18 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 			break;
 
 		case SPELL_Invis:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Invis, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Invis, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Incognito:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Incognito, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Incognito, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Paralyze:
 		case SPELL_Paralyze_Field:
 		case SPELL_Stone:
 		case SPELL_Particle_Form:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Paralyze, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Paralyze, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Mana_Vamp:
@@ -3373,12 +3373,12 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 
 		case SPELL_Light:
 			Effect(EFFECT_OBJ, iEffectID, this, 9, 6, fExplode, iColor, iRender);
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_NEWLIGHT, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_NEWLIGHT, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Hallucination:
 		{
-			CItem * pItem = Spell_Effect_Create( spell, LAYER_FLAG_Hallucination, iSkillLevel, 10*TICK_PER_SEC, pCharSrc );
+			CItem * pItem = Spell_Effect_Create( spell, LAYER_FLAG_Hallucination, iEffect, 10*TICK_PER_SEC, pCharSrc );
 			pItem->m_itSpell.m_spellcharges = Calc_GetRandVal(30);
 		}
 		break;
@@ -3437,24 +3437,24 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		case SPELL_Reaper_Form:
 		case SPELL_Polymorph:
 		{
-			Spell_Effect_Create(spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Polymorph, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Polymorph, iEffect, iDuration, pCharSrc);
 		}
 		break;
 
 		case SPELL_Chameleon:		// 106 // makes your skin match the colors of whatever is behind you.
 		case SPELL_BeastForm:		// 107 // polymorphs you into an animal for a while.
 		case SPELL_Monster_Form:	// 108 // polymorphs you into a monster for a while.
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Polymorph, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Polymorph, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Trance:			// 111 // temporarily increases your meditation skill.
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Shield:			// 113 // erects a temporary force field around you. Nobody approaching will be able to get within 1 tile of you, though you can move close to them if you wish.
 		case SPELL_Steelskin:		// 114 // turns your skin into steel, giving a boost to your AR.
 		case SPELL_Stoneskin:		// 115 // turns your skin into stone, giving a boost to your AR.
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Protection, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Protection, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Regenerate:		// Set number of charges based on effect level.
@@ -3462,38 +3462,38 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 			iDuration /= (2*TICK_PER_SEC);
 			if ( iDuration <= 0 )
 				iDuration = 1;
-			CItem * pSpell = Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iSkillLevel, iDuration, pCharSrc );
+			CItem * pSpell = Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iEffect, iDuration, pCharSrc );
 			ASSERT(pSpell);
 			pSpell->m_itSpell.m_spellcharges = iDuration;
 		}
 		break;
 
 		case SPELL_Blood_Oath:	// Blood Oath is a pact created between the casted and the target, memory is stored on the caster because one caster can have only 1 enemy, but one target can have the effect from various spells.
-			pCharSrc->Spell_Effect_Create(spell, LAYER_SPELL_Blood_Oath, iSkillLevel, iDuration, this);
+			pCharSrc->Spell_Effect_Create(spell, LAYER_SPELL_Blood_Oath, iEffect, iDuration, this);
 			break;
 
 		case SPELL_Corpse_Skin:
-			Spell_Effect_Create(spell, LAYER_SPELL_Corpse_Skin, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Corpse_Skin, iEffect, iDuration, pCharSrc);
 			break;
 
 		case SPELL_Evil_Omen:
-			Spell_Effect_Create(spell, LAYER_SPELL_Evil_Omen, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Evil_Omen, iEffect, iDuration, pCharSrc);
 			break;
 
 		case SPELL_Mind_Rot:
-			Spell_Effect_Create(spell, LAYER_SPELL_Mind_Rot, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Mind_Rot, iEffect, iDuration, pCharSrc);
 			break;
 
 		case SPELL_Pain_Spike:
-			Spell_Effect_Create(spell, LAYER_SPELL_Pain_Spike, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Pain_Spike, iEffect, iDuration, pCharSrc);
 			break;
 
 		case SPELL_Strangle:
-			Spell_Effect_Create(spell, LAYER_SPELL_Strangle, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Strangle, iEffect, iDuration, pCharSrc);
 			break;
 
 		case SPELL_Curse_Weapon:
-			Spell_Effect_Create(spell, LAYER_SPELL_Curse_Weapon, iSkillLevel, iDuration, pCharSrc);
+			Spell_Effect_Create(spell, LAYER_SPELL_Curse_Weapon, iEffect, iDuration, pCharSrc);
 			break;
 
 			/*case SPELL_Animate_Dead_AOS:

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3273,7 +3273,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 			break;
 
 		case SPELL_Night_Sight:
-			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Night_Sight, iSkillLevel, iDuration, pCharSrc );
+			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_Night_Sight, iEffect, iDuration, pCharSrc );
 			break;
 
 		case SPELL_Reactive_Armor:

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -1732,7 +1732,7 @@ CItem * CChar::Spell_Effect_Create( SPELL_TYPE spell, LAYER_TYPE layer, int iEff
 	// ARGS:
 	// spell = SPELL_Invis, etc.
 	// layer == LAYER_FLAG_Potion, etc.
-	// iSkillLevel = 0-1000 = skill level or other spell specific value.
+	// iEffect = The effect value, for spells is usually calculated by using g_Cfg.GetSpellEffect(spell, iSkillLevel) but other specific values can be used. 
 	// iDuration = TICK_PER_SEC
 	// bEquip automatically equips the memory, false requires manual equipment... usefull to setup everything before calling @MemoryEquip
 	//

--- a/src/game/chars/CCharUse.cpp
+++ b/src/game/chars/CCharUse.cpp
@@ -990,7 +990,7 @@ void CChar::Use_Drink( CItem * pItem )
 		}
 		else
 		{
-			CItem *pSpell = Spell_Effect_Create(SPELL_Liquor, LAYER_FLAG_Drunk, iStrength, 15 * TICK_PER_SEC, this);
+			CItem *pSpell = Spell_Effect_Create(SPELL_Liquor, LAYER_FLAG_Drunk, g_Cfg.GetSpellEffect(SPELL_Liquor, iStrength), 15 * TICK_PER_SEC, this);
 			pSpell->m_itSpell.m_spellcharges = 10;	// how long to last.
 		}
 	}
@@ -1016,7 +1016,7 @@ void CChar::Use_Drink( CItem * pItem )
 		OnSpellEffect(static_cast<SPELL_TYPE>(RES_GET_INDEX(pItem->m_itPotion.m_Type)), this, iSkillQuality, pItem);
 
 		// Give me the marker that i've used a potion.
-		Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_PotionUsed, iSkillQuality, 15 * TICK_PER_SEC, this);
+		Spell_Effect_Create(SPELL_NONE, LAYER_FLAG_PotionUsed, g_Cfg.GetSpellEffect(SPELL_NONE, iSkillQuality), 15 * TICK_PER_SEC, this);
 	}
 
 	if ( pItem->IsType(IT_DRINK) && IsSetOF(OF_DrinkIsFood) )

--- a/src/game/chars/CCharact.cpp
+++ b/src/game/chars/CCharact.cpp
@@ -2650,7 +2650,7 @@ bool CChar::SetPoison( int iSkill, int iTicks, CChar * pCharSrc )
 	}
 	else
 	{
-		pPoison = Spell_Effect_Create(SPELL_Poison, LAYER_FLAG_Poison, iSkill, 1 + Calc_GetRandVal(2) * TICK_PER_SEC, pCharSrc, false);
+		pPoison = Spell_Effect_Create(SPELL_Poison, LAYER_FLAG_Poison, g_Cfg.GetSpellEffect(SPELL_Poison, iSkill), 1 + Calc_GetRandVal(2) * TICK_PER_SEC, pCharSrc, false);
 		if ( !pPoison )
 		return false;
 		LayerAdd(pPoison, LAYER_FLAG_Poison);


### PR DESCRIPTION
local.effect value for the aforementioned spells.

Normally the effect value of a spell is calculated in OnSpellEffect (CCharSpell.cpp) by using:
int iEffect = g_Cfg.GetSpellEffect(spell, iSkillLevel);
Then the variable iEffect is also assigned to the local.effect trigger variable.

For spells that creates a "spell memory item" the method Spell_Effect_Create is also called, and inside of it the spell effect value is assigned to the MOREY
value of the "memory item" by using:
pSpell->m_itSpell.m_spelllevel = (word)(g_Cfg.GetSpellEffect(spell, iSkillLevel));

So i changed the parameter iSkillLevel of the method Spell_Effect_Create to use iEffect instead, the additional calculation seemed to me redundant because we had already calculated the spell effect value before and iSkillLevel is not even used for calculating "other things" in this method ( or in successive methods)

Additionally this change  allows to properly use the local.effect trigger variable with spells that equips a "spell memory item" (because we are passing iEffect instead of the skill level)

