### PR TITLE
Now ACTARG1/ACTARG2/ACTARG will be saved only if the following condit…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -348,4 +348,12 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 14-01-2018, Drk84
 - Fixed: The effect value of spells that equips a "memory item" on a character(Bless, Curse and so on) was calculated twice, also causing to ignore the 
 	value of local.effect.
-											
+	
+25-01-2018, Nolok & Drk84
+-Changed the way ACTARG1/ACTARG2/ACTARG3 are saved, they will be saved only if their value is different from 0 and the character's action is a valid skill or is one 
+	of the action that uses ACTARG1/ACTARG2/ACTARG3 (NPCACT_FLEE, NPCACT_TALK, NPCACT_TALKFOLLOW, NPCACT_RIDDEN).
+-Reverted the following changes made in a precedent commit for avoiding conflict with Spellcasting or custom scripts.
+	Removed the call to Skill_CleanUp method inside the trigger checks in Skill_UseQuick.
+	Removed the reset of ACTARG1/ACTARG2/ACTARG3 inside the Skill_CleanUp method.
+
+	

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -3338,12 +3338,19 @@ void CChar::r_Write( CScript & s )
 			sprintf(pszActionTemp, "%d", Skill_GetActive());
 		}
 		s.WriteKey("ACTION", pszActionTemp);
-		if ( m_atUnk.m_Arg1 )
+		/*We save ACTARG1/ACTARG2/ACTARG3 only if the following conditions are satisfied:
+		ACTARG1/ACTARG2/ACTARG3 is different from 0 AND
+		The character action is one of the valid skill OR
+		The character action is one of the NPC Action that uses ACTARG1/ACTARG2/ACTARG3
+		*/
+		SKILL_TYPE action = Skill_GetActive();
+		if ((m_atUnk.m_Arg1 != 0) && ((action > SKILL_NONE && action < SKILL_QTY) || action == NPCACT_FLEE || action == NPCACT_TALK || action == NPCACT_TALK_FOLLOW || action == NPCACT_RIDDEN))
 			s.WriteKeyHex("ACTARG1", m_atUnk.m_Arg1);
-		if ( m_atUnk.m_Arg2 )
+		if ((m_atUnk.m_Arg2 != 0) && ((action > SKILL_NONE && action < SKILL_QTY) || action == NPCACT_FLEE || action == NPCACT_TALK || action == NPCACT_TALK_FOLLOW || action == NPCACT_RIDDEN))
 			s.WriteKeyHex("ACTARG2", m_atUnk.m_Arg2);
-		if ( m_atUnk.m_Arg3 )
+		if ((m_atUnk.m_Arg3 != 0) && ((action > SKILL_NONE && action < SKILL_QTY) || action == NPCACT_FLEE || action == NPCACT_TALK || action == NPCACT_TALK_FOLLOW || action == NPCACT_RIDDEN))
 			s.WriteKeyHex("ACTARG3", m_atUnk.m_Arg3);
+
 	}
 
 	if ( m_virtualGold )

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -510,12 +510,10 @@ bool CChar::Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain,
 
 		if ( ret == TRIGRET_RET_TRUE )
 		{
-			Skill_Cleanup();
 			return true;
 		}
 		else if ( ret == TRIGRET_RET_FALSE )
 		{
-			Skill_Cleanup();
 			return false;
 		}
 	}
@@ -526,12 +524,10 @@ bool CChar::Skill_UseQuick( SKILL_TYPE skill, int64 difficulty, bool bAllowGain,
 
 		if ( ret == TRIGRET_RET_TRUE )
 		{
-			Skill_Cleanup();
 			return true;
 		}
 		else if ( ret == TRIGRET_RET_FALSE )
 		{
-			Skill_Cleanup();
 			return false;
 		}
 	}
@@ -555,7 +551,6 @@ void CChar::Skill_Cleanup()
 	ADDTOCALLSTACK("CChar::Skill_Cleanup");
 	// We are starting the skill or ended dealing with it (started / succeeded / failed / aborted)
 	m_Act_Difficulty = 0;
-	m_atUnk.m_Arg1 = m_atUnk.m_Arg2 = m_atUnk.m_Arg3 = 0;		// init ACTARG1/2/3
 	m_Act_SkillCurrent = SKILL_NONE;
 	SetTimeout( m_pPlayer ? -1 : TICK_PER_SEC );	// we should get a brain tick next time
 }


### PR DESCRIPTION
…ions are satisfied:

ACTARG1/ACTARG2/ACTARG3 is different from 0 AND
  The character action is one of the valid skill OR
  The character action is one of the NPC Action that uses ACTARG1/ACTARG2/ACTARG3

Also, reverted the following changes from a previous commit (https://github.com/drk84/Source2/commit/d9f2f25036302944220fa150e9f13be769925a24):
Removed the call to Skill_CleanUp method inside the trigger checks in Skill_UseQuick.
 Removed the reset of ACTARG1/ACTARG2/ACTARG3 inside the Skill_CleanUp method.