### PR TITLE
Commented 4 lines of in code in method Skill_Fight() (CCharSkill.cpp)…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -363,3 +363,8 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 29-01-2018, Nolok
 - Added: ini setting MaxLoopTimes is now controlling also the TIMERF executions. If too many TIMERFs are executed in the current tick, the loop will be aborted and a warning will be issued.
 	If it value is 0, there will be no limit (still it is suggested to set a value, even very high, because have just a distraction when writing some kind of scripts and you can cause a deadlock).
+
+31-01-2018, Drk84
+- Commented 3 lines of in code in method Skill_Fight() (CCharSkill.cpp), these 3 lines refers to a fix for an exploit in combat:
+  https://github.com/Sphereserver/Source/commit/c7f9055f60728ef44ac314e08c08751a02c09257
+  Because the lines above cause problems with combat swings and we don't know what the exploit is they were commented and replaced with Set_Timeout(0).

--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -365,6 +365,5 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 	If it value is 0, there will be no limit (still it is suggested to set a value, even very high, because have just a distraction when writing some kind of scripts and you can cause a deadlock).
 
 31-01-2018, Drk84
-- Commented 3 lines of in code in method Skill_Fight() (CCharSkill.cpp), these 3 lines refers to a fix for an exploit in combat:
-  https://github.com/Sphereserver/Source/commit/c7f9055f60728ef44ac314e08c08751a02c09257
+- Commented 4 lines of in code in method Skill_Fight() (CCharSkill.cpp), these 4 lines refers to a fix for an exploit in combat
   Because the lines above cause problems with combat swings and we don't know what the exploit is they were commented and replaced with Set_Timeout(0).

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2678,11 +2678,16 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 	if ( stage == SKTRIG_START )
 	{
 		m_atFight.m_War_Swing_State = WAR_SWING_EQUIPPING;
-		int64 iRemainingDelay = g_World.GetCurrentTime().GetTimeRaw() - m_atFight.m_timeNextCombatSwing;
-		if ( iRemainingDelay < 0 || iRemainingDelay > 255)
-			iRemainingDelay = 0;
 
+		/*The following 4 lines should fix an exploit related to combat, but because they cause problem with
+		combat swings timer and we don't know what the exploit is I have commented them.
+		int64 iRemainingDelay = g_World.GetCurrentTime().GetTimeRaw() - m_atFight.m_timeNextCombatSwing;
+		if (iRemainingDelay < 0 || iRemainingDelay > 255)
+			iRemainingDelay = 0;
 		SetTimeout(iRemainingDelay);
+		*/
+
+		SetTimeout(0);
 		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind());	// How difficult? 1-10000
 	}
 


### PR DESCRIPTION
These 4 lines refers to a fix for an exploit in combat:

  Sphereserver/Source@c7f9055
and
Sphereserver/Source@7259f54

  Because the lines above cause problems with combat swings and we don't know what the exploit is they were commented and replaced with Set_Timeout(0).