### PR TITLE
Port from Source addressing the following issue:

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -373,3 +373,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed the multi-threading and async networking system, which was disabled long time ago because of its instability.
 - Added ini flags: NetworkThreads (specify how many new network threads do you want), NetworkThreadPriority (priority of the dedicated networking threads),
 	UseAsyncNetwork (enable/disable asynchronous packet sending).
+
+02-02-2018
+- [Port from Source, 22-01-2018, Coruja]Fixed: Spells being disturbed even when they have INTERRUPT=0.0 set 

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1305,6 +1305,8 @@ bool CChar::Fight_Attack( const CChar *pCharTarg, bool btoldByMaster )
 
 	if ( skillActive == skillWeapon && m_Fight_Targ_UID == pCharTarg->GetUID() )		// already attacking this same target using the same skill
 		return true;
+	else if (g_Cfg.IsSkillFlag(skillActive, SKF_MAGIC))	// don't start another fight skill when already casting spells
+		return true;
 
 	if ( m_pNPC && !btoldByMaster )		// call FindBestTarget when this CChar is a NPC and was not commanded to attack, otherwise it attack directly
 		pTarget = NPC_FightFindBestTarget();


### PR DESCRIPTION
Spells being disturbed even when they have INTERRUPT=0.0 set
See:
https://github.com/Sphereserver/Source/commit/7ad1ca913393b0d46b9018b1e7a808d5491890ae

And:
https://github.com/Sphereserver/Source/issues/124

