### PR TITLE
Unhandled [TYPEDEF 40] error when creating a "chair" item, this was c…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -403,3 +403,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 18-02-2018, Nolok
 - Fixed: when an overloaded player drags an equippable item on himself, it returned to its previous location on the ground instead of at the player's feet.
+
+24-02-2018, Drk84
+- Fixed:  Unhandled [TYPEDEF 40] error when creating a "chair" item, this was caused by the removal of typedef t_chair in the scripts pack.

--- a/src/game/items/CItemBase.cpp
+++ b/src/game/items/CItemBase.cpp
@@ -75,10 +75,7 @@ CItemBase::CItemBase( ITEMID_TYPE id ) :
 
 	// Do some special processing for certain items.
 
-	if ( IsType(IT_CHAIR))
-		SetHeight( 0 ); // have no effective height if they don't block.
-	else
-		SetHeight( GetItemHeightFlags( tiledata, m_Can ));
+	SetHeight( GetItemHeightFlags( tiledata, m_Can ));
 
 	GetItemSpecificFlags( tiledata, m_Can, m_type, id );
 
@@ -796,8 +793,6 @@ IT_TYPE CItemBase::GetTypeBase( ITEMID_TYPE id, const CUOItemTypeRec_HS &tiledat
 
 	if ( IsID_WaterWash( id ) )
 		return IT_WATER_WASH;
-	else if ( IsID_Chair( id ) )
-		return IT_CHAIR;
 	else if ( IsID_Track( id ) )
 		return IT_FIGURINE;
 	else if ( IsID_GamePiece( id ) )

--- a/src/game/items/CItemBase.h
+++ b/src/game/items/CItemBase.h
@@ -60,7 +60,7 @@ enum IT_TYPE		// double click type action.
 	IT_FIGURINE,			// 37 = magic figure that turns into a creature when activated.
 	IT_SHRINE,				// 38 = can res you
 	IT_MOONGATE,			// 39 = linked to other moon gates (hard coded locations)
-	IT_CHAIR,				// 40 = Any sort of a chair item. we can sit on.
+	IT_UNUSED_40,			// 40 =This was typedef t_chair (Any sort of a chair item. we can sit on.)
 	IT_FORGE,				// 41 = used to smelt ore, blacksmithy etc.
 	IT_ORE,					// 42 = smelt to ingots.
 	IT_LOG,					// 43 = make into furniture etc. lumber,logs,


### PR DESCRIPTION
…aused by the removal of typedef t_chair in the scripts pack. The check for determining if an item is a chair or not  it's actually made by the IsId_Chair method. 